### PR TITLE
git: arreglado el nombre de los archivos generados por el LSP de Eclipse en el .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,6 @@ buildNumber.properties
 .mvn/wrapper/maven-wrapper.jar
 *.iml
 .direnv/
-.classpath/
-.project/
+.classpath
+.project
 .settings/


### PR DESCRIPTION
Algunos archivos tenia puesto el nombre como si fueran directorios.
