### PR TITLE
refactor mapa

### DIFF
--- a/src/main/java/edu/fiuba/algo3/modelo/mapa/Mapa.java
+++ b/src/main/java/edu/fiuba/algo3/modelo/mapa/Mapa.java
@@ -50,6 +50,10 @@ public class Mapa {
         }
     }
 
+    public boolean estaDentroDeLimites(int x, int y) {
+        return (0 <= x && x < this.limiteX) && (0 <= y && y < this.limiteY);
+    }
+
     public int getLimiteX() {
         return this.limiteX;
     }

--- a/src/main/java/edu/fiuba/algo3/modelo/mapa/Posicion.java
+++ b/src/main/java/edu/fiuba/algo3/modelo/mapa/Posicion.java
@@ -10,7 +10,7 @@ public class Posicion {
     }
 
     public boolean estaDentroDelMapa(Mapa mapa) {
-        return (0 <= this.x && this.x < mapa.getLimiteX()) && (0 <= this.y && this.y < mapa.getLimiteY());
+        return mapa.estaDentroDeLimites(this.x, this.y);
     }
 
     public Posicion sumar(int x, int y) {

--- a/src/main/test/edu/fiuba/algo3/modelo/mapa/MapaTest.java
+++ b/src/main/test/edu/fiuba/algo3/modelo/mapa/MapaTest.java
@@ -3,7 +3,9 @@ package edu.fiuba.algo3.modelo.mapa;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MapaTest {
     @Test
@@ -47,5 +49,16 @@ public class MapaTest {
         String mensajeEsperado = "Dimensiones menores o iguales a cero";
 
         assertEquals(mensajeRecibido, mensajeEsperado);
+    }
+
+    @Test
+    public void dadasDosCoordenadasSePuedeSaberSiEstasEstanDentroOFueraDeLosLimitesDelMapa() {
+        Mapa mapa = new Mapa(10, 10);
+
+        assertTrue(mapa.estaDentroDeLimites(0, 0));
+        assertTrue(mapa.estaDentroDeLimites(5, 5));
+        assertFalse(mapa.estaDentroDeLimites(0, 10));
+        assertFalse(mapa.estaDentroDeLimites(10, 0));
+        assertFalse(mapa.estaDentroDeLimites(10, 10));
     }
 }


### PR DESCRIPTION
- Agregue una interfaz de inicio. Los primeros tres botones comienzan un juego normal, los otros tres imprimen por pantalla
- refactor: ya no se utilizan los getters de mapa para determinar si una posicion esta dentro o fuera de este
